### PR TITLE
fix: fixing node install for homebrew package

### DIFF
--- a/Formula/magicbell-cli.rb
+++ b/Formula/magicbell-cli.rb
@@ -15,7 +15,7 @@ class MagicbellCli < Formula
   depends_on "node"
 
   def install
-    system "npm", "install", *Language::Node.std_npm_args(libexec)
+    system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 


### PR DESCRIPTION
Somehow the node install command changed, and the old one started breaking like so:

```sh
$ brew install magicbell-cli
==> Fetching magicbell/tap/magicbell-cli
==> Downloading https://registry.npmjs.org/@magicbell/cli/-/cli-4.1.0.tgz
Already downloaded: /Users/ullrich/Library/Caches/Homebrew/downloads/ee7d565ff569dfaab59eef660d4ebb64958b0a611a3e6b9afcb6240ac083c6cf--cli-4.1.0.tgz
==> Reinstalling magicbell/tap/magicbell-cli
Error: An exception occurred within a child process:
  NoMethodError: undefined method `std_npm_args' for module Language::Node
```

https://github.com/Homebrew/brew/pull/17867 does something along the line as well, and also update the documentation.